### PR TITLE
Add ".graphqls" as a GraphQL file extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1772,6 +1772,7 @@ GraphQL:
   type: data
   extensions:
   - ".graphql"
+  - ".graphqls"
   - ".gql"
   tm_scope: source.graphql
   ace_mode: text


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Often, developers use .graphqls specifically for GraphQL schemas to separate them from GraphQL queries, which are put into .graphql files.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?l=&p=100&q=type+extension%3Agraphqls&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/GraphQl/etc/schema.graphqls
      - https://github.com/digiaonline/graphql-php/blob/f9b538f074f961c74bfe941106b7a1da9630e404/tests/Functional/Language/schema-kitchen-sink.graphqls
    - Sample license(s): 
      - Open Software License ("OSL") (Magento)
      - MIT (graphql-php)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.